### PR TITLE
Remove a.name e a.href que servem para voltar da nota para o texto

### DIFF
--- a/documentstore_migracao/utils/convert_html_body.py
+++ b/documentstore_migracao/utils/convert_html_body.py
@@ -97,7 +97,7 @@ class HTML2SPSPipeline(object):
             self.EmPipe(),
             self.UPipe(),
             self.BPipe(),
-            # self.APipe(),
+            self.APipe(),
             self.StrongPipe(),
             self.TdCleanPipe(),
             self.TableCleanPipe(),
@@ -326,6 +326,10 @@ class HTML2SPSPipeline(object):
             return data
 
     class ANamePipe(plumber.Pipe):
+
+        def find_a_href(self, root, _id_name):
+            return root.find('.//a[@href="#{}"]'.format(_id_name))
+
         def parser_node(self, node):
             attrib = node.attrib
 
@@ -334,8 +338,16 @@ class HTML2SPSPipeline(object):
             if _id_name.startswith("top") or _id_name.startswith("back"):
                 return
 
-            if _id_name.startswith("t"):
-                node.tag = "table-wrap"
+            root = node.getroottree()
+            if _id_name.startswith("tx"):
+                _remove_element_or_comment(node)
+                _remove_element_or_comment(self.find_a_href(root, _id_name))
+            elif _id_name.startswith("t"):
+                a_href = self.find_a_href(root, _id_name)
+                if a_href and a_href.text and 'tab' in a_href.text.lower():
+                    node.tag = "table-wrap"
+                else:
+                    node.tag = "fn"
             elif _id_name[0] in "fcq":
                 node.tag = "fig"
             elif _id_name.startswith("n"):
@@ -553,6 +565,7 @@ class HTML2SPSPipeline(object):
                 ):
                     node.remove(list_c_node[0])
                 _remove_element_or_comment(node)
+
 
             node.attrib.clear()
             root = node.getroottree()

--- a/tests/test_convert_html_body.py
+++ b/tests/test_convert_html_body.py
@@ -456,6 +456,22 @@ class TestHTML2SPSPipeline(unittest.TestCase):
 
     #     self.assertEqual(new_xml.find("xref").attrib["rid"], "home")
 
+    def test_pipe_aname__removes_navigation_to_note_go_and_back(self):
+        text = """<root><a href="#tx01">
+            <graphic xmlns:ns2="http://www.w3.org/1999/xlink" ns2:href="/img/revistas/gs/v29n2/seta.gif"/>
+        </a><a name="tx01" id="tx01"/></root>"""
+
+        raw, transformed = self._transform(text, self.pipeline.ANamePipe())
+
+        node = transformed.find(".//xref")
+        self.assertIsNone(node)
+
+        node = transformed.find(".//a")
+        self.assertIsNone(node)
+
+        node = transformed.find(".//graphic")
+        self.assertIsNotNone(node)
+
     def test_pipe_a_anchor__remove_xref_with_graphic(self):
         text = """<root><a href="#top">
             <graphic xmlns:ns2="http://www.w3.org/1999/xlink" ns2:href="/img/revistas/gs/v29n2/seta.gif"/>
@@ -582,7 +598,7 @@ class TestHTML2SPSPipeline(unittest.TestCase):
         text = '<root><td width="" height="" style="style"><p>Teste</p></td></root>'
         raw, transformed = self._transform(text, self.pipeline.TdCleanPipe())
         self.assertEqual(
-            etree.tostring(transformed), b'<root><td style="style">Teste</td></root>'
+            etree.tostring(transformed), b'<root><td style="style"><p>Teste</p></td></root>'
         )
 
     def test_pipe_blockquote(self):


### PR DESCRIPTION
#### O que esse PR faz?
Foi encontrado o caso de a.name e a.href que servem de voltar da nota para o texto. Isso é excedente no XML, portanto, pode ser eliminado. Mas como o a.name começa com 't' então tem-se que distinguir entre 't' de tabela.

#### Onde a revisão poderia começar?
`python setup.py test -s tests.test_convert_html_body.TestHTML2SPSPipeline.test_pipe_aname__removes_navigation_to_note_go_and_back`


#### Como este poderia ser testado manualmente?
N/A

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
https://github.com/scieloorg/document-store-migracao/issues/112

### Referências
N/A
